### PR TITLE
Parse aooverlaps for ADF

### DIFF
--- a/src/cclib/method/__init__.py
+++ b/src/cclib/method/__init__.py
@@ -10,12 +10,13 @@
 
 """Example analyses and calculations based on data parsed by cclib."""
 
-from .density import Density
-from .cspa import CSPA
-from .mpa import MPA
-from .lpa import LPA
-from .opa import OPA
-from .mbo import MBO
-from .nuclear import Nuclear
-from .fragments import FragmentAnalysis
 from .cda import CDA
+from .cspa import CSPA
+from .density import Density
+from .fragments import FragmentAnalysis
+from .lpa import LPA
+from .mbo import MBO
+from .mpa import MPA
+from .nuclear import Nuclear
+from .opa import OPA
+from .volume import Volume

--- a/src/cclib/method/calculationmethod.py
+++ b/src/cclib/method/calculationmethod.py
@@ -1,23 +1,34 @@
 # This file is part of cclib (http://cclib.github.io), a library for parsing
 # and interpreting the results of computational chemistry packages.
 #
-# Copyright (C) 2006-2014, the cclib development team
+# Copyright (C) 2006-2015, the cclib development team
 #
 # The library is free software, distributed under the terms of
 # the GNU Lesser General Public version 2.1 or later. You should have
 # received a copy of the license along with cclib. You can also access
 # the full license online at http://www.gnu.org/copyleft/lgpl.html.
 
+"""Abstract based class for cclib methods."""
+
 import logging
 import sys
 
-"""Abstract based method class."""
 
 class Method(object):
-    """Abstract class for method classes.
+    """Abstract base class for all cclib method classes.
 
     Subclasses defined by cclib:
-        CDA, CSPA, Density, FragmentAnalysis, LPA, MBO, MPA, Nuclear, OPA, Population, Volume
+        CDA - charde decomposition analysis
+        CSPA - C-squared population analysis
+        Density - density matrix calculation
+        FragmentAnalysis - fragment analysis for ADF output
+        LPA - Löwdin population analysis
+        MBO - Mayer's bond orders
+        MPA - Mulliken population analysis
+        Nuclear - properties of atomic nuclei
+        OPA - overlap population analysis
+        Population - base class for population analyses
+        Volume - volume/grid calculations
 
     All the modules containing methods should be importable:
     >>> import cda, cspa, density, fragments, lpa, mbo, mpa, nuclear, opa, population, volume

--- a/src/cclib/method/population.py
+++ b/src/cclib/method/population.py
@@ -1,7 +1,7 @@
 # This file is part of cclib (http://cclib.github.io), a library for parsing
 # and interpreting the results of computational chemistry packages.
 #
-# Copyright (C) 2006-2014, the cclib development team
+# Copyright (C) 2006-2015, the cclib development team
 #
 # The library is free software, distributed under the terms of
 # the GNU Lesser General Public version 2.1 or later. You should have

--- a/test/regression.py
+++ b/test/regression.py
@@ -622,8 +622,8 @@ old_unittests = {
     "ADF/ADF2004.01/dvb_sp_b.adfout":       ADFSPTest,
     "ADF/ADF2004.01/dvb_sp_c.adfout":       ADFSPTest_nosyms_valence,
     "ADF/ADF2004.01/dvb_sp_d.adfout":       ADFSPTest_nosyms,
-    "ADF/ADF2004.01/dvb_un_sp.adfout":      ADFSPunTest,
-    "ADF/ADF2004.01/dvb_un_sp_c.adfout":    ADFSPunTest,
+    "ADF/ADF2004.01/dvb_un_sp.adfout":      GenericSPunTest,
+    "ADF/ADF2004.01/dvb_un_sp_c.adfout":    GenericSPunTest,
     "ADF/ADF2004.01/dvb_ir.adfout":         GenericIRTest,
 
     "ADF/ADF2006.01/dvb_gopt.adfout":       ADFGeoOptTest,

--- a/test/testSP.py
+++ b/test/testSP.py
@@ -117,27 +117,25 @@ class GenericSPTest(bettertest.TestCase):
         self.assertEquals(self.data.mocoeffs[0].shape,
                           (self.data.nmo, self.data.nbasis))
 
-    def testdimaooverlaps(self):
-        """Are the dims of the overlap matrix consistent with nbasis?"""
-
-        # ADF has the attribute fooverlaps instead of aooverlaps.
-        if not hasattr(self.data, "aooverlaps") and hasattr(self.data, "fooverlaps"):
-            self.data.aooverlaps = self.data.fooverlaps
+    def testaooverlaps(self):
+        """Are the dims and values of the overlap matrix correct?"""
 
         self.assertEquals(self.data.aooverlaps.shape, (self.data.nbasis, self.data.nbasis))
 
-    def testaooverlaps(self):
-        """Is the overlap matrix diagonal with expected values?"""
-
-        # ADF has the attribute fooverlaps instead of aooverlaps.
-        if not hasattr(self.data, "aooverlaps") and hasattr(self.data, "fooverlaps"):
-            self.data.aooverlaps = self.data.fooverlaps
-
+        # The matrix is symmetric.
         row = self.data.aooverlaps[0,:]
         col = self.data.aooverlaps[:,0]
         self.assertEquals(sum(col - row), 0.0)
 
-        self.assertEquals(self.data.aooverlaps[0,0], 1.0)
+        # All values on diagonal should be exactly zero.
+        for i in range(self.data.nbasis):
+            self.assertEquals(self.data.aooverlaps[i,i], 1.0)
+
+        # Check some additional values that don't seem to move around between programs.
+        self.assertInside(self.data.aooverlaps[0, 1], 0.24, 0.01)
+        self.assertInside(self.data.aooverlaps[1, 0], 0.24, 0.01)
+        self.assertEquals(self.data.aooverlaps[2,0], 0.0)
+        self.assertEquals(self.data.aooverlaps[0,2], 0.0)
 
     def testoptdone(self):
         """There should be no optdone attribute set."""
@@ -206,6 +204,19 @@ class ADFSPTest(GenericSPTest):
         """Is the SCF energy within 1eV of -140eV?"""
         self.assertInside(self.data.scfenergies[-1],-140,1,"Final scf energy: %f not -140+-1eV" % self.data.scfenergies[-1])
 
+    def testfoverlaps(self):
+        """Are the dims and values of the fragment orbital overlap matrix correct?"""
+
+        self.assertEquals(self.data.fooverlaps.shape, (self.data.nbasis, self.data.nbasis))
+
+        # The matrix is symmetric.
+        row = self.data.aooverlaps[0,:]
+        col = self.data.aooverlaps[:,0]
+        self.assertEquals(sum(col - row), 0.0)
+
+        # All diagonals should be close to zero.
+        for i in range(self.data.nbasis):
+            self.assertInside(self.data.aooverlaps[i,i], 1.0, 0.001)
 
 class GaussianSPTest(GenericSPTest):
     """Customized restricted single point unittest"""


### PR DESCRIPTION
Also added some extra tests for off-diagonal values in the overlap matrix, which should hold for all programs.

One ADF regression now fails... where the parsed value of `nbasis` (from SFO count) does not work for the Smat output.